### PR TITLE
Fix: autocmd pattern must be UpperCamelCase

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Please note that you can add extra functionality by listening to the `OptionSet
 background` autocmd event.
 
 If you would not like darkman.nvim to set `background`, you may set
-`send_user_event=true`. In which case the `User Darkmode` or `User Lightmode`
+`send_user_event=true`. In which case the `User DarkMode` or `User LightMode`
 events will be triggered instead.
 
 If the `colorscheme` option is set to a table with `dark` and `light` keys, the


### PR DESCRIPTION
Per https://github.com/4e554c4c/darkman.nvim/blob/150aa63a13837c44abd87ff20d3a806321a17b2d/main.go#L42 and https://github.com/4e554c4c/darkman.nvim/blob/150aa63a13837c44abd87ff20d3a806321a17b2d/main.go#L47 the pattern is in UpperCamelCase.