### PR TITLE
fix: treat `color-scheme` of value `0` (no preference) as light mode

### DIFF
--- a/main.go
+++ b/main.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	UNKNOWN = iota
+	NO_PREFERENCE = iota
 	DARK
 	LIGHT
 	UNINITIALIZED
@@ -43,7 +43,7 @@ func (args *setupArgs) handleNewMode() error {
 		if args.Colorscheme != nil {
 			colorscheme = args.Colorscheme.Dark
 		}
-	case LIGHT:
+	case LIGHT, NO_PREFERENCE:
 		background, event = "light", "LightMode"
 		if args.Colorscheme != nil {
 			colorscheme = args.Colorscheme.Light


### PR DESCRIPTION
Some environments (including GNOME) only expose the values of `0` (no preference) and `1` (prefer dark) in the settings. Currently, the plugin only handles values of `1` and `2`, with `0` leading to an error. This is fixed by treating `0` as light mode.

Fixes #6